### PR TITLE
[Shared-components] add tableOptions props to set or override bootstrap table options

### DIFF
--- a/frontend/.sharedComponents/table/components/Table.vue
+++ b/frontend/.sharedComponents/table/components/Table.vue
@@ -24,35 +24,32 @@
 
     <b-row>
       <b-col cols="12">
-        <b-table
-          data-cy="table"
-          striped
-          hover
-          bordered
-          small
-          no-sort-reset
-          show-empty
-          responsive="sm"
-          :selectable="selectable"
-          :items="items"
-          :fields="fields"
-          :no-local-sorting="true"
-          @sort-changed="onSortChanged"
-          @row-selected="onRowSelected"
-        >
-          <template
-            v-for="slotName of Object.keys($scopedSlots)"
-            v-slot:[slotName]="slotScope"
+        <b-container class="overflow-auto p-0 m-0">
+          <b-table
+            class="m-0 p-0"
+            data-cy="table"
+            v-bind="mergedOptions"
+            :selectable="selectable"
+            :items="items"
+            :fields="fields"
+            :no-local-sorting="true"
+            @sort-changed="onSortChanged"
+            @row-selected="onRowSelected"
           >
-            <slot :name="slotName" v-bind="slotScope"></slot>
-          </template>
-        </b-table>
+            <template
+              v-for="slotName of Object.keys($scopedSlots)"
+              v-slot:[slotName]="slotScope"
+            >
+              <slot :name="slotName" v-bind="slotScope"></slot>
+            </template>
+          </b-table>
+        </b-container>
         <b-pagination
           v-model="_currentPage"
           :total-rows="totalRows"
           align="fill"
           size="sm"
-          class="my-0 d-flex pull-right"
+          class="mt-2 d-flex pull-right"
           :per-page="_perPage"
         ></b-pagination>
       </b-col>
@@ -61,7 +58,7 @@
 </template>
 
 <script>
-import { ref, watch, reactive } from '@vue/composition-api';
+import { ref, watch, reactive, computed } from '@vue/composition-api';
 
 export default {
   name: 'Table',
@@ -103,20 +100,40 @@ export default {
       type: Number,
       required: false,
       default: 0
+    },
+    tableOptions: {
+      type: Object,
+      required: false,
+      default: () => {}
     }
   },
   setup(props, { emit }) {
     let _currentPage = ref(props.currentPage);
     let _perPage = ref(props.perPage);
 
+    const defaultTableOptions = {
+      striped: true,
+      hover: true,
+      bordered: true,
+      small: true,
+      responsive: 'sm',
+      'no-sort-reset': true,
+      'show-empty': true
+    };
+
     watch(_currentPage, value => {
       emit('page-changed', value);
+    });
+
+    const mergedOptions = computed(() => {
+      return { ...props.tableOptions, ...defaultTableOptions };
     });
 
     return {
       filter: ref(''),
       _currentPage,
       _perPage: reactive(props.perPage),
+      mergedOptions,
       onSortChanged: data => {
         emit('sort-changed', data);
       },

--- a/frontend/.sharedComponents/table/views/Table.vue
+++ b/frontend/.sharedComponents/table/views/Table.vue
@@ -17,6 +17,7 @@
       :current-page="currentPage"
       :per-page="perPage"
       :total-rows="totalRows"
+      :tableOptions="tableOptions"
       @sort-changed="onSortChanged"
       @row-selected="handleEvent"
       @filtered="onFilterChanged"
@@ -96,6 +97,9 @@ export default {
     let fields = ref([]);
     let document = ref({});
     let modalAction = ref('');
+    let tableOptions = ref({
+      // set here all bootstrap table supported props
+    });
 
     const fetchItems = () => {
       let query = {};


### PR DESCRIPTION
## What does this PR do ?
Add tableOptions props to the `Table` shared components to give possibilty to set or override all bootstrap table options.